### PR TITLE
Issue #5 Use release style URL as fallback for snapshot artifacts

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 
 group=com.rbmhtechnology
 name=apidoc-server
-version=1.0.2
+version=1.0.3-SNAPSHOT
 javaVersion=1.8
 
 # #########################################################################################

--- a/rbmhtechnology.properties
+++ b/rbmhtechnology.properties
@@ -1,0 +1,39 @@
+# name (default: ApiDoc Server)
+name=RBMH Docs
+
+# classifier to be used if no classifier is specified within request (default: javadoc)
+# default.classifier=
+
+# configure a path for storing apidoc jars, if not set a temp directory is used
+# localstorage=
+
+# Host of the Maven Repository (default: http://jcenter.bintray.com)
+repository.url=https://repository.redbullmediabase.com/content/groups/mediabase
+
+# username to access the maven repository
+repository.username=developer
+
+# password to access maven repository
+repository.password=72sYXg944nFy
+
+# set to false, to deactivate snapshot serving  (default: true)
+repository.snapshots.enabled=true
+
+# timeout of the snapshot download url in seconds (default: 1800 [30 minutes])
+repository.snapshots.cache-timeout=30
+
+# if specified this prefix whitelist limits the access to certain group ids
+# groupid-prefix-whitelist=
+
+# Disable all actuator endpoints beside info and health
+endpoints.autoconfig.enabled=false
+endpoints.beans.enabled=false
+endpoints.configprops.enabled=false
+endpoints.dump.enabled=false
+endpoints.env.enabled=false
+endpoints.health.enabled=true
+endpoints.info.enabled=true
+endpoints.metrics.enabled=false
+endpoints.mappings.enabled=false
+endpoints.shutdown.enabled=false
+endpoints.trace.enabled=false

--- a/src/main/java/com/rbmhtechnology/apidocserver/service/RepositoryService.java
+++ b/src/main/java/com/rbmhtechnology/apidocserver/service/RepositoryService.java
@@ -370,7 +370,10 @@ public class RepositoryService {
 			throw new RepositoryException("Could not parse maven-metadata.xml for '" + artifactIdentifier + "'", e);
 		}
 
-		throw new RepositoryException("Could not determine snapshot apidoc file name!");
+		// in case of a snapshot which has no reliable information coming from
+		// maven-metadata.xml simply use the pattern for releases
+		return artifactIdentifier.getArtifactId() + "-" + artifactIdentifier.getVersion() + "-"
+				+ artifactIdentifier.getClassifier() + ".jar";
 	}
 
 	/**


### PR DESCRIPTION
Use release style URL as fallback for snapshot artifacts  in case of information missing in maven-metadata.xml.
Normally we require information about classifieres and most recent snapshot version to construct the download url