### PR TITLE
Upgrade Guava version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,4 +11,4 @@ javaVersion=1.8
 # Dependency Versions
 # #########################################################################################
 httpClientVersion=4.4
-guavaVersion=18.0
+guavaVersion=28.1-jre


### PR DESCRIPTION
Due to frequent error scenario application is failing to download a non-cached artifact the upgrade of internally used Guava LoadingCache library is proposed.